### PR TITLE
Feature/take back moves

### DIFF
--- a/include/libsanjego/bot.hpp
+++ b/include/libsanjego/bot.hpp
@@ -84,10 +84,11 @@ SearchResult FullExplorer<HEIGHT, WIDTH>::Explore(
   auto best_move = Move::Skip();
   if (!possible_moves.empty()) {
     auto max_rating = std::numeric_limits<game_value_t>::min();
+    auto tmp_board(board);
     for (auto &move : possible_moves) {
-      auto tmp_board(board);
       tmp_board.Make(move);
       const auto rating = this->rules->ComputeValueOf(tmp_board);
+      tmp_board.Undo(move);
       if (rating > max_rating) {
         max_rating = rating;
         best_move = move;

--- a/include/libsanjego/gameobjects.hpp
+++ b/include/libsanjego/gameobjects.hpp
@@ -98,10 +98,13 @@ bool exceeds_border(const Position &position) {
  * A move a player wants to make in a game.
  * This does not mean a move object is necessarily legal; it depends on the
  * ruleset used.
+ * If a move is applied to a board, the target tower may be stored in this
+ * struct's affected_tower field to simplify reverting moves.
  */
 struct Move {
   Position source;
   Position target;
+  std::optional<Tower> affected_tower;
 
   bool operator==(const Move &other) const noexcept;
   Move &operator=(const Move &other) = default;
@@ -140,6 +143,7 @@ class Board {
         this->field[details::to_array_index(move.source, Width())];
     auto &targetTower =
         this->field[details::to_array_index(move.target, Width())];
+    move.affected_tower = targetTower;
     targetTower.Attach(sourceTower);
     sourceTower.Clear();
     return true;

--- a/include/libsanjego/gameobjects.hpp
+++ b/include/libsanjego/gameobjects.hpp
@@ -48,8 +48,42 @@ class Tower {
   /*
    * Adds the given tower on top of *this* one. As a result, their heights are
    * added and the top brick is now the same as tower's.
+   *
+   * Example:
+   *   ```cpp
+   *   // initial situation (ground is left)
+   *   // source: |BBY
+   *   // target: |B
+   *
+   *   target.Attach(source)
+   *
+   *   // source: |BBY
+   *   // target: |BBBY
+   *   ```
    */
   void Attach(const Tower tower);
+
+  /*
+   * Removes the given tower from the bottom of *this* one. It is the inverse
+   * operation of Attach (note that the arguments are also inverted).
+   * As a result, *this* tower is shortened by the height of the given tower,
+   * and its top brick is left untouched. If the given tower does not form the
+   * bottom of *this* tower (leaving at least one brick in *this* instance), the
+   * operation does nothing.
+   *
+   * Example:
+   *   ```cpp
+   *   // initial situation (ground is left)
+   *   // source: |BBBY
+   *   // target: |B
+   *
+   *   source.DetachFrom(target)
+   *
+   *   // source: |BBY
+   *   // target: |B
+   *   ```
+   */
+  void DetachFrom(const Tower tower);
 
   template <board_size_t HEIGHT, board_size_t WIDTH>
   friend class Board;

--- a/src/gameobjects.cpp
+++ b/src/gameobjects.cpp
@@ -52,6 +52,17 @@ void Tower::Attach(const Tower tower) {
   this->representation = pack(new_height, new_owner);
 }
 
+void Tower::DetachFrom(const Tower tower) {
+  const auto thisHeight = this->Height();
+  const auto otherHeight = tower.Height();
+  if (otherHeight >= thisHeight) {
+    return;
+  }
+  const auto new_height = thisHeight - otherHeight;
+  const auto new_owner = this->Top();
+  this->representation = pack(new_height, new_owner);
+}
+
 bool Move::operator==(const Move &other) const noexcept {
   return this->source == other.source && this->target == other.target;
 }

--- a/test/test_gameobjects.cpp
+++ b/test/test_gameobjects.cpp
@@ -87,6 +87,28 @@ TEST_CASE("Attached towers keep their top brick", "[fast]") {
   }
 }
 
+TEST_CASE("Detaching towers subtracts their heights", "[fast]") {
+  const Tower source(Color::Blue);
+  Tower target(Color::Yellow);
+  const Tower originalTarget(target);
+
+  target.Attach(source);
+
+  target.DetachFrom(originalTarget);
+  REQUIRE(target.Height() == source.Height());
+}
+
+TEST_CASE("Detaching towers restores top brick", "[fast]") {
+  const Tower source(Color::Blue);
+  Tower target(Color::Yellow);
+  const Tower originalTarget(target);
+
+  target.Attach(source);
+
+  target.DetachFrom(originalTarget);
+  REQUIRE(target.Top() == source.Top());
+}
+
 TEST_CASE("Positions are equal if both coordinates are equal", "[fast]") {
   const Position pos1{0, 1};
   const Position pos2{0, 1};


### PR DESCRIPTION
By allowing to take back moves, search algorithms can save a lot of expensive copy operations.